### PR TITLE
fix: use zenodo api access token if available

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -47,3 +47,8 @@ PUBLIC_SSHOC_BASE_URL="https://marketplace.sshopencloud.eu"
 BASEROW_API_BASE_URL="https://baserow.acdh-dev.oeaw.ac.at"
 BASEROW_API_KEY=
 BASEROW_TABLE_ID=
+
+# -------------------------------------------------------------------------------------------------
+# zenodo api
+# -------------------------------------------------------------------------------------------------
+ZENODO_API_ACCESS_TOKEN=

--- a/src/config/env.config.ts
+++ b/src/config/env.config.ts
@@ -25,6 +25,7 @@ export const env = createEnv({
 			KEYSTATIC_GITHUB_CLIENT_ID: v.optional(v.pipe(v.string(), v.nonEmpty())),
 			KEYSTATIC_GITHUB_CLIENT_SECRET: v.optional(v.pipe(v.string(), v.nonEmpty())),
 			KEYSTATIC_SECRET: v.optional(v.pipe(v.string(), v.nonEmpty())),
+			ZENODO_API_ACCESS_TOKEN: v.optional(v.pipe(v.string(), v.nonEmpty())),
 		});
 		return v.parse(Schema, input);
 	},

--- a/src/pages/publications/index.astro
+++ b/src/pages/publications/index.astro
@@ -5,6 +5,7 @@ import { Image } from "astro:assets";
 import MainContent from "@/components/main-content.astro";
 import PageSection from "@/components/page-section.astro";
 import PageTitle from "@/components/page-title.astro";
+import { env } from "@/config/env.config";
 import { defaultLocale as locale } from "@/config/i18n.config";
 import PageLayout from "@/layouts/page-layout.astro";
 import { getImageImport } from "@/lib/get-image-import";
@@ -110,7 +111,14 @@ async function getAllPublications() {
 			}),
 		});
 
-		response = await fetch(url).then((response) => {
+		const headers =
+			env.ZENODO_API_ACCESS_TOKEN != null
+				? {
+						Authorization: `Bearer ${env.ZENODO_API_ACCESS_TOKEN}`,
+					}
+				: undefined;
+
+		response = await fetch(url, { headers }).then((response) => {
 			return response.json();
 		});
 


### PR DESCRIPTION
if a zenodo api access token is provided via environment variables, use it when retrieving publications.